### PR TITLE
Add a JSON formatter

### DIFF
--- a/file/fileLogging.go
+++ b/file/fileLogging.go
@@ -22,6 +22,8 @@ const (
 	minFileLifeSpan         = time.Second
 	minSizeInMB             = uint64(1)
 	maxSizeInMB             = uint64(1024 * 1024) // 1TB
+	logFileExtension        = "log"
+	logFileAsJsonExtension  = "jsonl"
 )
 
 var log = logger.GetOrCreate("common/logging")
@@ -102,10 +104,10 @@ func (fl *fileLogging) createFile() (*os.File, error) {
 
 func (fl *fileLogging) decideFileExtension() string {
 	if fl.logAsJson {
-		return "jsonl"
+		return logFileAsJsonExtension
 	}
 
-	return "log"
+	return logFileExtension
 }
 
 func (fl *fileLogging) recreateLogFile() {

--- a/file/fileLogging.go
+++ b/file/fileLogging.go
@@ -40,6 +40,7 @@ type fileLogging struct {
 	workingDir              string
 	defaultLogsPath         string
 	logFilePrefix           string
+	logAsJson               bool
 	cancelFunc              func()
 	mutIsClosed             sync.Mutex
 	lifeSpanSize            uint64
@@ -54,6 +55,7 @@ type ArgsFileLogging struct {
 	WorkingDir      string
 	DefaultLogsPath string
 	LogFilePrefix   string
+	LogAsJson       bool
 }
 
 // NewFileLogging creates a file log watcher used to break the log file into multiple smaller files
@@ -62,6 +64,7 @@ func NewFileLogging(args ArgsFileLogging) (*fileLogging, error) {
 		workingDir:      args.WorkingDir,
 		defaultLogsPath: args.DefaultLogsPath,
 		logFilePrefix:   args.LogFilePrefix,
+		logAsJson:       args.LogAsJson,
 		isClosed:        false,
 		lifeSpanSize:    defaultFileSizeInMB * oneMegaByte,
 		notifyChan:      make(chan struct{}),
@@ -108,7 +111,7 @@ func (fl *fileLogging) recreateLogFile() {
 	defer fl.mutOperation.Unlock()
 
 	oldFile := fl.currentFile
-	err = logger.AddLogObserver(newFile, &logger.PlainFormatter{})
+	err = logger.AddLogObserver(newFile, fl.decideFormatter())
 	if err != nil {
 		log.Error("error adding log observer", "error", err)
 		return
@@ -130,6 +133,14 @@ func (fl *fileLogging) recreateLogFile() {
 	log.LogIfError(errNotCritical, "step", "removing old log observer")
 
 	fl.timeBasedLogLifeSpanner.reset()
+}
+
+func (fl *fileLogging) decideFormatter() logger.Formatter {
+	if fl.logAsJson {
+		return &logger.JSONFormatter{}
+	}
+
+	return &logger.PlainFormatter{}
 }
 
 func (fl *fileLogging) autoRecreateFile(ctx context.Context) {

--- a/file/fileLogging.go
+++ b/file/fileLogging.go
@@ -95,9 +95,17 @@ func (fl *fileLogging) createFile() (*os.File, error) {
 		core.ArgCreateFileArgument{
 			Prefix:        fl.logFilePrefix,
 			Directory:     logDirectory,
-			FileExtension: "log",
+			FileExtension: fl.decideFileExtension(),
 		},
 	)
+}
+
+func (fl *fileLogging) decideFileExtension() string {
+	if fl.logAsJson {
+		return "jsonl"
+	}
+
+	return "log"
 }
 
 func (fl *fileLogging) recreateLogFile() {

--- a/jsonFormatter.go
+++ b/jsonFormatter.go
@@ -1,0 +1,28 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type JsonFormatter struct {
+}
+
+// Output converts the provided LogLineHandler into a slice of bytes ready for output
+func (pf *JsonFormatter) Output(line LogLineHandler) []byte {
+	if line == nil {
+		return nil
+	}
+
+	output, err := json.Marshal(line)
+	if err != nil {
+		return []byte(fmt.Sprintf("error marshalling log line: %s", err.Error()))
+	}
+
+	return output
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (pf *JsonFormatter) IsInterfaceNil() bool {
+	return pf == nil
+}

--- a/jsonFormatter.go
+++ b/jsonFormatter.go
@@ -16,7 +16,7 @@ func (pf *JSONFormatter) Output(line LogLineHandler) []byte {
 
 	output, err := json.Marshal(line)
 	if err != nil {
-		return []byte(fmt.Sprintf("error marshalling log line: %s", err.Error()))
+		return []byte(fmt.Sprintf("error marshalling log line: %s\n", err.Error()))
 	}
 
 	output = append(output, '\n')

--- a/jsonFormatter.go
+++ b/jsonFormatter.go
@@ -8,19 +8,66 @@ import (
 type JSONFormatter struct {
 }
 
+type jsonOptimizedLogLine struct {
+	Timestamp  int64    `json:"t"`
+	LogLevel   int32    `json:"l"`
+	LoggerName string   `json:"n,omitempty"`
+	Message    string   `json:"m,omitempty"`
+	Args       []string `json:"a,omitempty"`
+}
+
+type jsonOptimizedLogLineWithCorrelation struct {
+	Timestamp  int64    `json:"t"`
+	LogLevel   int32    `json:"l"`
+	LoggerName string   `json:"n,omitempty"`
+	Shard      string   `json:"s"`
+	Epoch      uint32   `json:"e"`
+	Round      int64    `json:"r"`
+	SubRound   string   `json:"sr"`
+	Message    string   `json:"m,omitempty"`
+	Args       []string `json:"a,omitempty"`
+}
+
 // Output converts the provided LogLineHandler into a slice of bytes ready for output
 func (pf *JSONFormatter) Output(line LogLineHandler) []byte {
 	if line == nil {
 		return nil
 	}
 
-	output, err := json.Marshal(line)
+	optimizedLine := getOptimizedLogLine(line)
+	output, err := json.Marshal(optimizedLine)
 	if err != nil {
-		return []byte(fmt.Sprintf("error marshalling log line: %s\n", err.Error()))
+		// Generally speaking, this is dead code, since the structures are well-defined and can always be marshalled.
+		errorMessage := fmt.Sprintf("error marshalling log line: %s, %s: %s\n", line.GetLoggerName(), line.GetMessage(), err.Error())
+		return []byte(errorMessage)
 	}
 
 	output = append(output, '\n')
 	return output
+}
+
+func getOptimizedLogLine(line LogLineHandler) interface{} {
+	if IsEnabledCorrelation() {
+		return &jsonOptimizedLogLineWithCorrelation{
+			Timestamp:  line.GetTimestamp(),
+			LogLevel:   line.GetLogLevel(),
+			LoggerName: line.GetLoggerName(),
+			Shard:      line.GetCorrelation().Shard,
+			Epoch:      line.GetCorrelation().Epoch,
+			Round:      line.GetCorrelation().Round,
+			SubRound:   line.GetCorrelation().SubRound,
+			Message:    line.GetMessage(),
+			Args:       line.GetArgs(),
+		}
+	}
+
+	return &jsonOptimizedLogLine{
+		Timestamp:  line.GetTimestamp(),
+		LogLevel:   line.GetLogLevel(),
+		LoggerName: line.GetLoggerName(),
+		Message:    line.GetMessage(),
+		Args:       line.GetArgs(),
+	}
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/jsonFormatter.go
+++ b/jsonFormatter.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 )
 
-type JsonFormatter struct {
+type JSONFormatter struct {
 }
 
 // Output converts the provided LogLineHandler into a slice of bytes ready for output
-func (pf *JsonFormatter) Output(line LogLineHandler) []byte {
+func (pf *JSONFormatter) Output(line LogLineHandler) []byte {
 	if line == nil {
 		return nil
 	}
@@ -19,10 +19,11 @@ func (pf *JsonFormatter) Output(line LogLineHandler) []byte {
 		return []byte(fmt.Sprintf("error marshalling log line: %s", err.Error()))
 	}
 
+	output = append(output, '\n')
 	return output
 }
 
 // IsInterfaceNil returns true if there is no value under the interface
-func (pf *JsonFormatter) IsInterfaceNil() bool {
+func (pf *JSONFormatter) IsInterfaceNil() bool {
 	return pf == nil
 }

--- a/jsonFormatter_test.go
+++ b/jsonFormatter_test.go
@@ -8,19 +8,15 @@ import (
 )
 
 func TestJSONFormatter_Output(t *testing.T) {
-	t.Parallel()
-
 	formatter := &JSONFormatter{}
 
 	t.Run("with nil line", func(t *testing.T) {
-		t.Parallel()
-
 		output := formatter.Output(nil)
 		require.Nil(t, output)
 	})
 
-	t.Run("with line", func(t *testing.T) {
-		t.Parallel()
+	t.Run("with line (without correlation)", func(t *testing.T) {
+		ToggleCorrelation(false)
 
 		line := &LogLineWrapper{
 			LogLineMessage: proto.LogLineMessage{
@@ -34,17 +30,41 @@ func TestJSONFormatter_Output(t *testing.T) {
 
 		output := formatter.Output(line)
 		require.NotNil(t, output)
-		require.Equal(t, `{"Message":"bar","LogLevel":2,"Args":["a","42","b","43"],"Timestamp":1122334455,"LoggerName":"foo","Correlation":{}}`+"\n", string(output))
+		require.Equal(t, `{"t":1122334455,"l":2,"n":"foo","m":"bar","a":["a","42","b","43"]}`+"\n", string(output))
+	})
+
+	t.Run("with line (with correlation)", func(t *testing.T) {
+		ToggleCorrelation(true)
+
+		line := &LogLineWrapper{
+			LogLineMessage: proto.LogLineMessage{
+				LoggerName: "foo",
+				Message:    "bar",
+				LogLevel:   int32(LogInfo),
+				Args:       []string{"a", "42", "b", "43"},
+				Timestamp:  1122334455,
+				Correlation: proto.LogCorrelationMessage{
+					Shard:    "3",
+					Epoch:    42,
+					Round:    4343,
+					SubRound: "end",
+				},
+			},
+		}
+
+		output := formatter.Output(line)
+		require.NotNil(t, output)
+		require.Equal(t, `{"t":1122334455,"l":2,"n":"foo","s":"3","e":42,"r":4343,"sr":"end","m":"bar","a":["a","42","b","43"]}`+"\n", string(output))
 	})
 
 	t.Run("with bad line", func(t *testing.T) {
-		t.Parallel()
+		ToggleCorrelation(false)
 
 		line := &badLogLine{}
 
 		output := formatter.Output(line)
 		require.NotNil(t, output)
-		require.Equal(t, "error marshalling log line: json: unsupported type: func()\n", string(output))
+		require.Equal(t, `{"t":0,"l":0}`+"\n", string(output))
 	})
 }
 

--- a/jsonFormatter_test.go
+++ b/jsonFormatter_test.go
@@ -1,0 +1,59 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-logger-go/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONFormatter_Output(t *testing.T) {
+	t.Parallel()
+
+	formatter := &JSONFormatter{}
+
+	t.Run("with nil line", func(t *testing.T) {
+		t.Parallel()
+
+		output := formatter.Output(nil)
+		require.Nil(t, output)
+	})
+
+	t.Run("with line", func(t *testing.T) {
+		t.Parallel()
+
+		line := &LogLineWrapper{
+			LogLineMessage: proto.LogLineMessage{
+				LoggerName: "foo",
+				Message:    "bar",
+				LogLevel:   int32(LogInfo),
+				Args:       []string{"a", "42", "b", "43"},
+				Timestamp:  1122334455,
+			},
+		}
+
+		output := formatter.Output(line)
+		require.NotNil(t, output)
+		require.Equal(t, `{"Message":"bar","LogLevel":2,"Args":["a","42","b","43"],"Timestamp":1122334455,"LoggerName":"foo","Correlation":{}}`+"\n", string(output))
+	})
+
+	t.Run("with bad line", func(t *testing.T) {
+		t.Parallel()
+
+		line := &badLogLine{}
+
+		output := formatter.Output(line)
+		require.NotNil(t, output)
+		require.Equal(t, "error marshalling log line: json: unsupported type: func()\n", string(output))
+	})
+}
+
+type badLogLine struct {
+	proto.LogLineMessage
+	NotMarshalizable func() `json:"notMarshalizable"`
+}
+
+// IsInterfaceNil -
+func (line *badLogLine) IsInterfaceNil() bool {
+	return false
+}

--- a/logSubsystem.go
+++ b/logSubsystem.go
@@ -128,7 +128,7 @@ func AddLogObserver(w io.Writer, formatter Formatter) error {
 	return defaultLogOut.AddObserver(w, formatter)
 }
 
-// RemoveLogObserver removes an exiting observer by providing the writer pointer.
+// RemoveLogObserver removes an existing observer by providing the writer pointer.
 func RemoveLogObserver(w io.Writer) error {
 	return defaultLogOut.RemoveObserver(w)
 }


### PR DESCRIPTION
Output logs as newline-separated JSON.

Example:
```
{"t":1733818556457877716,"l":1,"n":"process/sync","s":"1","e":0,"r":872859,"sr":"(START_ROUND)","m":"computeNodeState","a":["probableHighestNonce","871289","currentBlockNonce","870772","boot.hasLastBlock","false"]}
{"t":1733818556457950125,"l":1,"n":"process/sync","s":"1","e":0,"r":872859,"sr":"(START_ROUND)","m":"computeNodeState","a":["isNodeStateCalculated","true","isNodeSynchronized","false"]}
{"t":1733818556457926413,"l":1,"n":"process/track","s":"1","e":0,"r":872859,"sr":"(START_ROUND)","m":"received shard header from network in block tracker","a":["shard","1","epoch","726","round","872358","nonce","870788","hash","cb527848d1e521e4de8f426a201f12023cbef25dab925e00b63337b95f74317a"]}
{"t":1733818556457984132,"l":1,"n":"statusHandler","s":"1","e":0,"r":872859,"sr":"(START_ROUND)","m":"processStatusHandler.SetBusy","a":["reason","shardProcessor.ProcessBlock"]}
{"t":1733818556457989706,"l":1,"n":"process/sync","s":"1","e":0,"r":872859,"sr":"(START_ROUND)","m":"forkDetector.AddHeader","a":["round","872358","nonce","870788","hash","cb527848d1e521e4de8f426a201f12023cbef25dab925e00b63337b95f74317a","state","1","probable highest nonce","871289","last checkpoint nonce","870772","final checkpoint nonce","870770"]}
```

Legend:

```
t - timestamp
l - logLevel
n - loggerName

etc.
```

References:
 - https://en.wikipedia.org/wiki/JSON_streaming